### PR TITLE
DOCSP-45419-typo

### DIFF
--- a/source/run-java-queries.txt
+++ b/source/run-java-queries.txt
@@ -38,7 +38,7 @@ Example
 -------
 
 In this example, the Java query on the ``production.trips`` collection
-resemles the following:
+resembles the following:
 
 .. code:: java
    :copyable: false


### PR DESCRIPTION
Addresses "resemles" typo on **Run Java Queries**.