### PR TITLE
DOCSP-45629-fixes-js-block-on-Run-Java-Queries

### DIFF
--- a/source/run-java-queries.txt
+++ b/source/run-java-queries.txt
@@ -60,12 +60,12 @@ above.
 
    db.getSiblingsDB("production")
      .getCollection("trips")
-     .find( { 
-        "$and" : [ 
+     .find({
+        "$and" : [
            { "trip_status" : "completed" },
            { "driver_id" : driver_id }
-        ]
-      )
+         ],
+     })
 
 In this example, ``driver_id`` is a variable that holds a value 
 determined at runtime. In order to test that your query outputs the 


### PR DESCRIPTION
# DESCRIPTION

Fixes syntax error in code block on **Run Java Queries**. Syntax now correctly matches the image that appears below.

# STAGING

https://deploy-preview-14--docs-mongodb-intellij.netlify.app/run-java-queries/#example

# JIRA

https://jira.mongodb.org/browse/DOCSP-45629